### PR TITLE
Added *_path_rfc6570 and *_url_rfc6570 helpers like Rails ones.

### DIFF
--- a/lib/rails/rfc6570.rb
+++ b/lib/rails/rfc6570.rb
@@ -176,10 +176,16 @@ module Rails
       end
 
       def method_missing(mth, *args, &block)
-        if mth =~ /^(\w+)_rfc6570$/
-          rfc6570_route $1
-        else
-          super
+        opts = args.first || {}
+        case mth
+          when /^(\w+)_path_rfc6570$/
+            rfc6570_route $1, opts.merge(path_only: true)
+          when /^(\w+)_url_rfc6570$/
+            rfc6570_route $1, opts.merge(path_only: false) # independent of whatever future defaults
+          when /^(\w+)_rfc6570$/
+            rfc6570_route $1, opts
+          else
+            super
         end
       end
     end

--- a/spec/rfc6570_spec.rb
+++ b/spec/rfc6570_spec.rb
@@ -29,6 +29,8 @@ class APIController < ApplicationController
   def action
     render json: {
       template: action_rfc6570,
+      template_url: action_url_rfc6570,
+      template_path: action_path_rfc6570,
       partial: test6_rfc6570.partial_expand(title: 'TITLE'),
       expand: test6_rfc6570.expand(capture: %w(a b), title: 'TITLE')
     }
@@ -84,6 +86,14 @@ describe Rails::RFC6570, type: :request do
 
     it 'should allow to return and render templates' do
       expect(json['template']).to eq "#{host}/action{?param1,param2}"
+    end
+
+    it 'should allow to return and render url templates' do
+      expect(json['template_url']).to eq "#{host}/action{?param1,param2}"
+    end
+
+    it 'should allow to return and render path templates' do
+      expect(json['template_path']).to eq "/action{?param1,param2}"
     end
 
     it 'should allow to return and render partial expanded templates' do


### PR DESCRIPTION
Also fixed missing opts argument for *_rfc6570 helpers.

These changes add convenient way to make path-only RFC6570 templates. 
RFC6570 is very convenient to use on both client and server sides, but path-only templates are more convenient to build "web-client-only" version of API (independence from hostname).
