### PR TITLE
Refactor into visitor and formatter

### DIFF
--- a/lib/rails/rfc6570.rb
+++ b/lib/rails/rfc6570.rb
@@ -1,168 +1,10 @@
 # frozen_string_literal: true
 
+require 'action_dispatch/journey'
+
+require 'rails/rfc6570/formatter'
 require 'rails/rfc6570/version'
-
-module ActionDispatch
-  module Journey
-    module Visitors
-      class RFC6570 < Visitor # rubocop:disable ClassLength
-        DISPATCH_CACHE = {} # rubocop:disable MutableConstant
-
-        def initialize(opts = {})
-          super()
-
-          @opts        = opts
-          @stack       = []
-          @group_depth = 0
-        end
-
-        def ignore
-          @opts.fetch(:ignore) { %w[format] }
-        end
-
-        def route
-          @route ||= @opts[:route]
-        end
-
-        # rubocop:disable AbcSize
-        def accept(node)
-          str = visit(node)
-
-          if @opts.fetch(:params, true) && route
-            controller = route.defaults[:controller].to_s
-            action     = route.defaults[:action].to_s
-
-            if controller.present? && action.present?
-              params = Rails::RFC6570.params_for(controller, action)
-              str += '{?' + params.join(',') + '}' if params&.any?
-            end
-          end
-
-          str
-        end
-        # rubocop:enable all
-
-        def visit(node)
-          @stack.unshift node.type
-          send DISPATCH_CACHE.fetch(node.type), node
-        ensure
-          @stack.shift
-        end
-
-        def symbol_name(node)
-          name = node.to_s.tr '*:', ''
-
-          if ignore.include?(name)
-            nil
-          else
-            name
-          end
-        end
-
-        def placeholder(node, prefix = nil, suffix = nil, pretext = nil)
-          name = symbol_name node
-          if name
-            "#{pretext}{#{prefix}#{name}#{suffix}}"
-          else
-            ''
-          end
-        end
-
-        # rubocop:disable AbcSize
-        # rubocop:disable CyclomaticComplexity
-        # rubocop:disable MethodLength
-        # rubocop:disable PerceivedComplexity
-        def binary(node)
-          case [node.left.type, node.right.type]
-            when %i[DOT SYMBOL]
-              if @stack[0..1] == %i[CAT GROUP]
-                placeholder node.right, '.'
-              else
-                placeholder(node.right, nil, nil, '.')
-              end
-            when %i[SLASH SYMBOL]
-              if @stack[0..1] == %i[CAT GROUP]
-                placeholder(node.right, '/')
-              else
-                placeholder(node.right, nil, nil, '/')
-              end
-            when %i[SLASH STAR]
-              placeholder node.right, '/', '*'
-            when %i[SLASH CAT]
-              if node.right.left.type == :STAR
-                placeholder(node.right.left, '/', '*') +
-                  visit(node.right.right)
-              else
-                [visit(node.left), visit(node.right)].join
-              end
-            when %i[CAT STAR]
-              visit(node.left).to_s.gsub(%r{/+$}, '') +
-                placeholder(node.right, '/', '*')
-            else
-              [visit(node.left), visit(node.right)].join
-          end
-        end
-        # rubocop:enable all
-
-        def terminal(node)
-          node.left
-        end
-
-        def nary(node)
-          node.children.each {|c| visit(c) }
-        end
-
-        def unary(node)
-          visit(node.left)
-        end
-
-        # rubocop:disable MethodName
-        def visit_CAT(node)
-          binary(node)
-        end
-
-        def visit_LITERAL(node)
-          terminal(node)
-        end
-
-        def visit_SLASH(node)
-          terminal(node)
-        end
-
-        def visit_DOT(node)
-          terminal(node)
-        end
-
-        def visit_SYMBOL(node)
-          placeholder(node)
-        end
-
-        def visit_OR(node)
-          nary(node)
-        end
-
-        def visit_STAR(node)
-          unary(node)
-        end
-
-        def visit_GROUP(node)
-          raise 'Cannot transform nested groups.' if @group_depth >= 1
-
-          @group_depth += 1
-          visit node.left
-        ensure
-          @group_depth -= 1
-        end
-        # rubocop:enable MethodName
-
-        instance_methods(true).each do |meth|
-          next unless meth =~ /^visit_(.*)$/
-          DISPATCH_CACHE[Regexp.last_match(1).to_sym] = meth
-        end
-      end
-    end
-  end
-end
+require 'rails/rfc6570/visitor'
 
 module Rails
   module RFC6570
@@ -170,7 +12,6 @@ module Rails
       class Railtie < ::Rails::Railtie # :nodoc:
         initializer 'rails-rfc6570', group: :all do |_app|
           require 'rails/rfc6570/patches'
-          require 'action_dispatch/journey'
 
           MAJOR = Rails::VERSION::MAJOR
           MINOR = Rails::VERSION::MINOR
@@ -183,9 +24,6 @@ module Rails
 
           ::ActionDispatch::Journey::Route.send :include,
             Rails::RFC6570::Extensions::JourneyRoute
-
-          ::ActionDispatch::Journey::Nodes::Node.send :include,
-            Rails::RFC6570::Extensions::JourneyNode
 
           ::ActiveSupport.on_load(:action_controller) do
             include Rails::RFC6570::Helper
@@ -207,7 +45,6 @@ module Rails
           Hash[routes.map {|n, r| [n, r.to_rfc6570(opts)] }]
         end
 
-        # rubocop:disable AbcSize
         # rubocop:disable MethodLength
         def define_rfc6570_helpers(name, route, mod, set)
           rfc6570_name      = :"#{name}_rfc6570"
@@ -224,11 +61,13 @@ module Rails
             end
 
             define_method(rfc6570_url_name) do |opts = {}|
-              send rfc6570_name, opts.merge(path_only: false)
+              ::Rails::RFC6570.build_url_template(self, route,
+                opts.merge(path_only: false))
             end
 
             define_method(rfc6570_path_name) do |opts = {}|
-              send rfc6570_name, opts.merge(path_only: true)
+              ::Rails::RFC6570.build_url_template(self, route,
+                opts.merge(path_only: true))
             end
           end
 
@@ -248,14 +87,8 @@ module Rails
 
       module JourneyRoute
         def to_rfc6570(opts = {})
-          path.spec.to_rfc6570 opts.merge(route: self)
-        end
-      end
-
-      module JourneyNode
-        def to_rfc6570(opts = {})
-          ::Addressable::Template.new \
-            ::ActionDispatch::Journey::Visitors::RFC6570.new(opts).accept(self)
+          @rfc6570_formatter ||= RFC6570::Formatter.new(self)
+          @rfc6570_formatter.evaluate(opts)
         end
       end
     end
@@ -274,7 +107,7 @@ module Rails
         route = Rails.application.routes.named_routes[name]
         raise KeyError.new "No named routed for `#{name}'." unless route
 
-        ::Rails::RFC6570.build_url_template(self, route, opts)
+        route.to_rfc6570(**opts, ctx: self)
       end
     end
 
@@ -292,34 +125,15 @@ module Rails
       end
     end
 
-    # rubocop:disable MethodLength
-    def build_url_template(t, route, options)
-      template = route.to_rfc6570(options)
-
-      if options.fetch(:path_only, false)
-        template
-      else
-        options = t.url_options.merge(options)
-        options[:path] = template.pattern
-
-        original_script_name = options.delete(:original_script_name)
-
-        if original_script_name
-          options[:script_name] = original_script_name + options[:script_name]
-        end
-
-        url = ActionDispatch::Http::URL.url_for(options)
-
-        ::Addressable::Template.new(url)
-      end
-    end
-    # rubocop:enable all
-
     def params_for(controller, action)
       ctr = "#{controller.camelize}Controller".constantize
       ctr.rfc6570_defs[action.to_sym] if ctr.respond_to?(:rfc6570_defs)
     rescue NameError
       nil
+    end
+
+    def build_url_template(ctx, route, **kwargs)
+      route.to_rfc6570(ctx: ctx, **kwargs)
     end
 
     extend self # rubocop:disable ModuleFunction

--- a/lib/rails/rfc6570/formatter.rb
+++ b/lib/rails/rfc6570/formatter.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+module Rails
+  module RFC6570
+    class Formatter
+      attr_reader :route
+
+      def initialize(route)
+        @route = route
+        @parts = Visitor.new(factory: method(:symbol)).accept(route.path.spec)
+      end
+
+      def evaluate(ignore: %w[format], ctx:, **kwargs)
+        parts = @parts.reject do |part|
+          part.is_a?(Subst) && ignore.include?(part.name)
+        end
+
+        if kwargs.fetch(:params, true) && route
+          controller = route.defaults[:controller].to_s
+          action     = route.defaults[:action].to_s
+
+          if controller.present? && action.present?
+            params = ::Rails::RFC6570.params_for(controller, action)
+            parts << '{?' + params.join(',') + '}' if params&.any?
+          end
+        end
+
+        if kwargs.fetch(:path_only, false)
+          ::Addressable::Template.new parts.join
+        else
+          options = ctx.url_options.merge(kwargs)
+          options[:path] = parts.join
+
+          if (osn = options.delete(:original_script_name))
+            options[:script_name] = osn + options[:script_name]
+          end
+
+          ::Addressable::Template.new \
+            ActionDispatch::Http::URL.url_for(options)
+        end
+      end
+
+      def symbol(node, prefix: nil, suffix: nil)
+        Subst.new(node.name, "{#{prefix}#{node.name}#{suffix}}")
+      end
+
+      Subst = Struct.new(:name, :to_s)
+    end
+  end
+end

--- a/lib/rails/rfc6570/visitor.rb
+++ b/lib/rails/rfc6570/visitor.rb
@@ -1,0 +1,120 @@
+# frozen_string_literal: true
+
+module Rails
+  module RFC6570
+    class Visitor < ::ActionDispatch::Journey::Visitors::Visitor
+      DISPATCH_CACHE = {} # rubocop:disable MutableConstant
+
+      def initialize(factory: nil)
+        super()
+
+        @stack   = []
+        @factory = factory || method(:symbolize)
+      end
+
+      def accept(node)
+        Array(visit(node)).flatten
+      end
+
+      def visit(node)
+        @stack.unshift node.type
+        send DISPATCH_CACHE.fetch(node.type), node
+      ensure
+        @stack.shift
+      end
+
+      def terminal(node)
+        node.left
+      end
+
+      # rubocop:disable MethodName
+      def visit_CAT(node)
+        if (mth = DISPATCH_CACHE[:"#{node.left.type}_#{node.right.type}"])
+          send mth, node.left, node.right
+        else
+          [visit(node.left), visit(node.right)]
+        end
+      end
+
+      def visit_LITERAL(node)
+        terminal(node)
+      end
+
+      def visit_SLASH(node)
+        terminal(node)
+      end
+
+      def visit_DOT(node)
+        terminal(node)
+      end
+
+      def visit_SYMBOL(node)
+        symbol(node)
+      end
+
+      def visit_OR(_node)
+        raise 'OR nodes cannot be serialized to URI templates'
+      end
+
+      def visit_GROUP(node)
+        # if @stack.include?(:GROUP) && @stack[1..-1].include?(:GROUP)
+        #   raise 'Cannot transform nested groups.'
+        # end
+
+        visit node.left
+      end
+
+      def visit_DOT_SYMBOL(dot, node)
+        if @stack[0..1] == %i[CAT GROUP]
+          symbol(node, prefix: '.')
+        else
+          [visit(dot), visit(node)]
+        end
+      end
+
+      def visit_SLASH_SYMBOL(slash, node)
+        if @stack[0..1] == %i[CAT GROUP]
+          symbol(node, prefix: '/')
+        else
+          [visit(slash), visit(node)]
+        end
+      end
+
+      # rubocop:disable AbcSize
+      def visit_SLASH_CAT(slash, cat)
+        if cat.left.type == :STAR
+          [symbol(cat.left.left, prefix: '/', suffix: '*'), visit(cat.right)]
+        elsif cat.left.type == :SYMBOL && @stack[0..1] == %i[CAT GROUP]
+          [symbol(cat.left, prefix: '/'), visit(cat.right)]
+        else
+          [visit(slash), visit(cat)]
+        end
+      end
+      # rubocop:enable AbcSize
+
+      def visit_SLASH_STAR(_slash, star)
+        symbol(star.left, prefix: '/', suffix: '*')
+      end
+
+      def visit_STAR_CAT(star, cat)
+        [symbol(star.left, prefix: '/', suffix: '*'), visit(cat)]
+      end
+      # rubocop:enable MethodName
+
+      instance_methods(true).each do |meth|
+        next unless meth =~ /^visit_(.*)$/
+        DISPATCH_CACHE[Regexp.last_match(1).to_sym] = meth
+      end
+
+      private
+
+      def symbol(node, **kwargs)
+        @factory.call(node, **kwargs)
+      end
+
+      def symbolize(node, prefix: nil, suffix: nil)
+        "{#{prefix}#{node.name}#{suffix}}"
+      end
+    end
+  end
+end

--- a/spec/rails/rfc6570/visitor_spec.rb
+++ b/spec/rails/rfc6570/visitor_spec.rb
@@ -1,0 +1,113 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe ::Rails::RFC6570::Visitor do
+  let(:visitor) { described_class.new }
+  let(:node) { ::ActionDispatch::Journey::Parser.new.parse(path) }
+
+  subject { visitor.accept(node) }
+
+  describe '/' do
+    let(:path) { '/' }
+    it { is_expected.to eq %w[/] }
+  end
+
+  describe '/path/path' do
+    let(:path) { '/path/path' }
+    it { is_expected.to eq %w[/ path / path] }
+  end
+
+  describe '/:title' do
+    let(:path) { '/:title' }
+    it { is_expected.to eq %w[/ {title}] }
+  end
+
+  describe '/:title(.:format)' do
+    let(:path) { '/:title(.:format)' }
+    it { is_expected.to eq %w[/ {title} {.format}] }
+  end
+
+  describe '/path/:title' do
+    let(:path) { '/path/:title' }
+    it { is_expected.to eq %w[/ path / {title}] }
+  end
+
+  describe '/path/pre-(:id)-post' do
+    let(:path) { '/path/pre-(:id)-post' }
+    it { is_expected.to eq %w[/ path / pre- {id} -post] }
+  end
+
+  describe '/path(/:title)' do
+    let(:path) { '/path(/:title)' }
+    it { is_expected.to eq %w[/ path {/title}] }
+  end
+
+  describe '/path/*capture/:title' do
+    let(:path) { '/path/*capture/:title' }
+    it { is_expected.to eq %w[/ path {/capture*} / {title}] }
+  end
+
+  describe '/path(/*capture)/:title' do
+    let(:path) { '/path(/*capture)/:title' }
+    it { is_expected.to eq %w[/ path {/capture*} / {title}] }
+  end
+
+  describe '/path(/*capture)(/:title)' do
+    let(:path) { '/path(/*capture)(/:title)' }
+    it { is_expected.to eq %w[/ path {/capture*} {/title}] }
+  end
+
+  describe '*a/path/*b' do
+    let(:path) { '*a/path/*b' }
+    it { is_expected.to eq %w[{/a*} / path {/b*}] }
+  end
+
+  describe 'path/*a/path/*b' do
+    let(:path) { 'path/*a/path/*b' }
+    it { is_expected.to eq %w[path {/a*} / path {/b*}] }
+  end
+
+  describe 'path/*a/*b' do
+    let(:path) { 'path/*a/*b' }
+    it { is_expected.to eq %w[path {/a*} {/b*}] }
+  end
+
+  describe 'path/*a/:title' do
+    let(:path) { 'path/*a/:title' }
+    it { is_expected.to eq %w[path {/a*} / {title}] }
+  end
+
+  describe 'path/*a(/:title)' do
+    let(:path) { 'path/*a(/:title)' }
+    it { is_expected.to eq %w[path {/a*} {/title}] }
+  end
+
+  describe '/(:title)' do
+    let(:path) { '/(:title)' }
+    it { is_expected.to eq %w[/ {title}] }
+  end
+
+  describe '(/:title)' do
+    let(:path) { '(/:title)' }
+    it { is_expected.to eq %w[{/title}] }
+  end
+
+  describe '(/:title/)' do
+    let(:path) { '(/:title/)' }
+    it { is_expected.to eq %w[{/title} /] }
+  end
+
+  describe '(/:a(/:b))' do
+    let(:path) { '(/:a(/:b))' }
+    it { is_expected.to eq %w[{/a} {/b}] }
+  end
+
+  describe '(/a)|(/b)' do
+    let(:path) { '(/a)|(/b)' }
+    it do
+      expect { subject }.to \
+        raise_error 'OR nodes cannot be serialized to URI templates'
+    end
+  end
+end


### PR DESCRIPTION
    Refactor into visitor and formatter
    
    This refactors the visitor and URI template building to be faster, simpler
    and easier to test. It should be easier to add explicit caching too.
    
    The new RFC6570::Visitor only traverses the Journey AST to produces a
    list of parts needed to build an URI template. It does not filter for ignored
    substitutions nor append controller parameters to the part list. This
    means we can run this once for a route and reuse the much simpler and faster
    parts list for build customizable URI templates. The visitor uses its cached
    method dispatch for dual-node CAT clauses too, simplifying the implementation.
    Last but not least it got its own test suite too.
    
    The new RFC6570::Formatter uses the part list from a visitor to build URI
    templates. It filters for ignored substitutions, adds action parameters and
    contains all code needed to build path only or full URI templates. It further
    avoids creating templates twice when generating full URLs.

I've run a few micro benchmarks measuring directly building URI templates (no Rails route helpers):

#### Full URL (`path_only: false`)

```
Warming up --------------------------------------
            old     2.771k i/100ms
            new     7.307k i/100ms
Calculating -------------------------------------
            old     28.731k (± 2.3%) i/s -    144.092k in   5.018047s
            new     74.464k (± 8.1%) i/s -    372.657k in   5.045131s

Comparison:
            new:    74464.2 i/s
            old:    28731.0 i/s - 2.59x  slower
```

#### Path only

```
Warming up --------------------------------------
                 old     3.573k i/100ms
                 new    11.242k i/100ms
Calculating -------------------------------------
                 old     36.292k (± 2.9%) i/s -    182.223k in   5.025649s
                 new    123.714k (± 2.7%) i/s -    618.310k in   5.001772s

Comparison:
                 new:   123714.3 i/s
                 old:    36292.1 i/s - 3.41x  slower
```

This should be a considerable speed-up and be measurable in our applications.