### PR TITLE
chore: Update rubocop-config to v13

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ group :development do
   gem 'benchmark-ips'
   gem 'pry'
   gem 'pry-byebug'
-  gem 'rubocop-config', github: 'jgraichen/rubocop-config', ref: 'v12', require: false
+  gem 'rubocop-config', github: 'jgraichen/rubocop-config', tag: 'v13', require: false
 end
 
 group :test do

--- a/spec/dummy/config/application.rb
+++ b/spec/dummy/config/application.rb
@@ -1,5 +1,10 @@
 require File.expand_path('../boot', __FILE__)
 
+# Workaround for missing require "logger" in some Rails versions.
+#
+# See https://github.com/rails/rails/pull/54264.
+require 'logger'
+
 require 'rails/all'
 
 Bundler.require(*Rails.groups)
@@ -19,4 +24,3 @@ module Dummy
     # config.i18n.default_locale = :de
   end
 end
-


### PR DESCRIPTION
Use tag, not ref, so that updates are based on tags, not every commit.