### PR TITLE
fix: Remove unnecessary indirection via build_url_template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a Ch
 
 ### Changes
 
+- Optimize named `*_rfc6570` helpers by removing unnecessary indirection
+
 ### Fixes
 
 ### Breaks

--- a/lib/rails/rfc6570.rb
+++ b/lib/rails/rfc6570.rb
@@ -53,25 +53,15 @@ module Rails
 
           mod.module_eval do
             define_method(rfc6570_name) do |**opts|
-              ::Rails::RFC6570.build_url_template(self, route, **opts)
+              route.to_rfc6570(**opts, ctx: self)
             end
 
             define_method(rfc6570_url_name) do |**opts|
-              ::Rails::RFC6570.build_url_template(
-                self,
-                route,
-                **opts,
-                path_only: false,
-              )
+              route.to_rfc6570(**opts, ctx: self, path_only: false)
             end
 
             define_method(rfc6570_path_name) do |**opts|
-              ::Rails::RFC6570.build_url_template(
-                self,
-                route,
-                **opts,
-                path_only: true,
-              )
+              route.to_rfc6570(**opts, ctx: self, path_only: true)
             end
           end
 
@@ -133,10 +123,6 @@ module Rails
       ctr.rfc6570_defs[action.to_sym] if ctr.respond_to?(:rfc6570_defs)
     rescue NameError
       nil
-    end
-
-    def build_url_template(ctx, route, **kwargs)
-      route.to_rfc6570(ctx: ctx, **kwargs)
     end
 
     extend self # rubocop:disable Style/ModuleFunction


### PR DESCRIPTION
This global helper call isn't needed anymore, since to_rfc6570 can be called directly on the local route.