### PR TITLE
fix: Invalid args on RouteSet#to_rfc6570

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a Ch
 
 ### Fixes
 
+- Fix up `RouteSet#to_rfc6570` and `NamedRouteCollection#to_rfc6570`
+
 ### Breaks
 
 ## 3.3.0 - (2024-11-25)

--- a/lib/rails/rfc6570.rb
+++ b/lib/rails/rfc6570.rb
@@ -32,14 +32,14 @@ module Rails
 
     module Extensions
       module RouteSet
-        def to_rfc6570(opts = {})
-          routes.map {|r| r.to_rfc6570(opts) }
+        def to_rfc6570(**opts)
+          named_routes.to_rfc6570(**opts)
         end
       end
 
       module NamedRouteCollection
-        def to_rfc6570(opts = {})
-          routes.to_h {|n, r| [n, r.to_rfc6570(opts)] }
+        def to_rfc6570(**opts)
+          routes.to_h {|name, route| [name, route.to_rfc6570(**opts)] }
         end
 
         def define_rfc6570_helpers(name, route, mod, set)

--- a/spec/rails/rfc6570/extensions/route_set_spec.rb
+++ b/spec/rails/rfc6570/extensions/route_set_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Rails::RFC6570::Extensions::RouteSet do
+  subject(:route_set) do
+    ActionDispatch::Routing::RouteSet.new.tap do |routes|
+      routes.draw do
+        get '/path/:id', to: 'controller#action', as: :test1
+      end
+    end
+  end
+
+  let(:ctx) do
+    Class.new do
+      def url_options
+        {host: 'www.example.org'}
+      end
+    end.new
+  end
+
+  describe '#to_rfc6570' do
+    it 'returns dictionary of all named routes' do
+      expect(route_set.to_rfc6570(ctx: ctx)).to eq({
+        test1: Addressable::Template.new('http://www.example.org/path/{id}'),
+      })
+    end
+  end
+end


### PR DESCRIPTION
The two semi-public methods `RouteSet#to_rfc6570` and `NamedRouteCollection#to_rfc6570` were using the old, no longer working, kwargs format. Both methods are working again.

`RouteSet#to_rfc6570` has been adjusted to return a hash with named routes only, since the array before isn't much useful, and it was broken.

New specs explicitly test `RouteSet#to_rfc6570`, and, by indirection, `NamedRouteCollection#to_rfc6570`.