### PR TITLE
Support mounted Rails Engines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a Ch
 ### Fixes
 
 - Fix up `RouteSet#to_rfc6570` and `NamedRouteCollection#to_rfc6570`
+- Fix up `*_path_rfc6570` to include Rails Engines mount point.
 
 ### Breaks
 

--- a/lib/rails/rfc6570/formatter.rb
+++ b/lib/rails/rfc6570/formatter.rb
@@ -25,19 +25,16 @@ module Rails
           end
         end
 
-        if kwargs.fetch(:path_only, false)
-          ::Addressable::Template.new parts.join
-        else
-          options = ctx.url_options.merge(kwargs)
-          options[:path] = parts.join
+        options = ctx.url_options.merge(kwargs)
+        options[:path] = parts.join
+        options[:only_path] = kwargs.fetch(:path_only, false)
 
-          if (osn = options.delete(:original_script_name))
-            options[:script_name] = osn + options[:script_name]
-          end
-
-          ::Addressable::Template.new \
-            ActionDispatch::Http::URL.url_for(options)
+        if (osn = options.delete(:original_script_name))
+          options[:script_name] = osn + options[:script_name]
         end
+
+        ::Addressable::Template.new \
+          ActionDispatch::Http::URL.url_for(options)
       end
 
       def symbol(node, prefix: nil, suffix: nil)


### PR DESCRIPTION
Continuation of #42 because GitHub failed to accept pushes to editable PR branches.

---

The RFC6570 path-only code previously skipped the Rails URL generation backend but only returned the template path. This resulted in skipping the prefix from mounted engines.

The PR changes the code to always use `ActionDispatch::Http::URL.url_for` for all URL generation after expanding the template and to pass `only_path` as an option when needed. This way, full URL and path-only generation behave identically, and both will include the correct Rails mount paths now.