### PR TITLE
fix: `*_rfc6570` to support Hash argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ This project adheres to [Semantic Versioning](http://semver.org/) and [Keep a Ch
 
 ### Fixes
 
+- Fix up `*_rfc6570` to support a Hash argument. Required when calling template from Rails Engine in the main app.
+
 ### Breaks
 
 ## 3.5.0 - (2025-09-26)

--- a/lib/rails/rfc6570.rb
+++ b/lib/rails/rfc6570.rb
@@ -52,15 +52,15 @@ module Rails
           end
 
           mod.module_eval do
-            define_method(rfc6570_name) do |**opts|
+            define_method(rfc6570_name) do |opts = {}|
               route.to_rfc6570(**opts, ctx: self)
             end
 
-            define_method(rfc6570_url_name) do |**opts|
+            define_method(rfc6570_url_name) do |opts = {}|
               route.to_rfc6570(**opts, ctx: self, path_only: false)
             end
 
-            define_method(rfc6570_path_name) do |**opts|
+            define_method(rfc6570_path_name) do |opts = {}|
               route.to_rfc6570(**opts, ctx: self, path_only: true)
             end
           end

--- a/spec/rails/rfc6570_spec.rb
+++ b/spec/rails/rfc6570_spec.rb
@@ -61,6 +61,9 @@ class APIController < ApplicationController
       partial: test6_rfc6570.partial_expand(title: 'TITLE'),
       ignore: test6_rfc6570(ignore: %w[title]),
       expand: test6_rfc6570.expand(capture: %w[a b], title: 'TITLE'),
+      engine_template: dummy_engine.action_rfc6570,
+      engine_template_url: dummy_engine.action_url_rfc6570,
+      engine_template_path: dummy_engine.action_path_rfc6570,
     }
   end
 
@@ -147,6 +150,18 @@ describe Rails::RFC6570, type: :request do
 
     it 'allows to return and render expanded templates (II)' do
       expect(json['expand']).to eq "#{host}/path/a/b/TITLE"
+    end
+
+    it 'allows to return and render a rails engines templates' do
+      expect(json['engine_template']).to eq "#{host}/dummy_engine/action{?param3}"
+    end
+
+    it 'allows to return and render a rails engines url templates' do
+      expect(json['engine_template_url']).to eq "#{host}/dummy_engine/action{?param3}"
+    end
+
+    it 'allows to return and render a rails engines path templates' do
+      expect(json['engine_template_path']).to eq '/dummy_engine/action{?param3}'
     end
 
     context 'with origin_script_name' do


### PR DESCRIPTION
When a Rails Engines `*_rfc6570` method is called from the main app, the argument will be a hash. `*_rfc6570` needs to support both keyword arguments and a hash argument.